### PR TITLE
feat: add compare command to cli

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/open-feature/cli/internal/manifest"
+	"github.com/spf13/cobra"
+)
+
+func GetCompareCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "compare",
+		Short: "Compare two manifest files",
+		Long:  `Compare two manifest files and list the changes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("please provide two manifest files to compare")
+			}
+
+			oldManifest, err := manifest.Load(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to load old manifest: %w", err)
+			}
+
+			newManifest, err := manifest.Load(args[1])
+			if err != nil {
+				return fmt.Errorf("failed to load new manifest: %w", err)
+			}
+
+			changes, err := manifest.Compare(oldManifest, newManifest)
+			if err != nil {
+				return fmt.Errorf("failed to compare manifests: %w", err)
+			}
+
+			for _, change := range changes {
+				fmt.Printf("%s: %s\n", change.Type, change.Path)
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ func Execute(version string, commit string, date string) {
 
 func GetRootCmd() *cobra.Command {
 	// Execute all parent's persistent hooks
-	cobra.EnableTraverseRunHooks =true
+	cobra.EnableTraverseRunHooks = true
 
 	rootCmd := &cobra.Command{
 		Use:   "openfeature",
@@ -46,8 +46,8 @@ func GetRootCmd() *cobra.Command {
 
 			return nil
 		},
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		SilenceErrors:              true,
+		SilenceUsage:               true,
 		DisableSuggestions:         false,
 		SuggestionsMinimumDistance: 2,
 		DisableAutoGenTag:          true,
@@ -60,6 +60,7 @@ func GetRootCmd() *cobra.Command {
 	rootCmd.AddCommand(GetVersionCmd())
 	rootCmd.AddCommand(GetInitCmd())
 	rootCmd.AddCommand(GetGenerateCmd())
+	rootCmd.AddCommand(GetCompareCmd())
 
 	// Add a custom error handler after the command is created
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {

--- a/internal/manifest/compare_test.go
+++ b/internal/manifest/compare_test.go
@@ -1,0 +1,65 @@
+package manifest
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCompareDifferentManifests(t *testing.T) {
+	oldManifest := &Manifest{
+		Flags: map[string]any{
+			"flag1": "value1",
+			"flag2": "value2",
+		},
+	}
+
+	newManifest := &Manifest{
+		Flags: map[string]any{
+			"flag1": "value1",
+			"flag2": "newValue2",
+			"flag3": "value3",
+		},
+	}
+
+	changes, err := Compare(oldManifest, newManifest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedChanges := []Change{
+		{Type: "change", Path: "flags.flag2", OldValue: "value2", NewValue: "newValue2"},
+		{Type: "add", Path: "flags.flag3", NewValue: "value3"},
+	}
+
+	sortChanges(changes)
+	sortChanges(expectedChanges)
+
+	if !reflect.DeepEqual(changes, expectedChanges) {
+		t.Errorf("expected %v, got %v", expectedChanges, changes)
+	}
+}
+
+func TestCompareIdenticalManifests(t *testing.T) {
+	manifest := &Manifest{
+		Flags: map[string]any{
+			"flag1": "value1",
+			"flag2": "value2",
+		},
+	}
+
+	changes, err := Compare(manifest, manifest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(changes) != 0 {
+		t.Errorf("expected no changes, got %v", changes)
+	}
+}
+
+func sortChanges(changes []Change) {
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Path < changes[j].Path
+	})
+}

--- a/internal/manifest/manage.go
+++ b/internal/manifest/manage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/open-feature/cli/internal/filesystem"
+	"github.com/spf13/afero"
 )
 
 type initManifest struct {
@@ -14,7 +15,7 @@ type initManifest struct {
 // Create creates a new manifest file at the given path.
 func Create(path string) error {
 	m := &initManifest{
-		Schema:  "https://raw.githubusercontent.com/open-feature/cli/refs/heads/main/schema/v0/flag_manifest.json",
+		Schema: "https://raw.githubusercontent.com/open-feature/cli/refs/heads/main/schema/v0/flag_manifest.json",
 		Manifest: Manifest{
 			Flags: map[string]any{},
 		},
@@ -24,4 +25,20 @@ func Create(path string) error {
 		return err
 	}
 	return filesystem.WriteFile(path, formattedInitManifest)
+}
+
+// Load loads a manifest from a JSON file, unmarshals it, and returns a Manifest object.
+func Load(path string) (*Manifest, error) {
+	fs := filesystem.FileSystem()
+	data, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+
+	return &m, nil
 }


### PR DESCRIPTION
## This PR

### feat: add compare command to cli
A new 'compare' command has been added to the CLI. This command allows users to compare two manifest files and list the changes between them. The comparison is done by loading each manifest file, then using a new function from the 'manifest' package to identify differences. Error handling has also been implemented for scenarios where loading or comparing manifests fails.

### feat: add tests for manifest comparison
Added two new test functions in the 'manifest' package. The first function, 'TestCompareDifferentManifests', checks if the 'Compare' function correctly identifies changes between two different manifests. The second function, 'TestCompareIdenticalManifests', verifies that no changes are reported when comparing identical manifests. Both tests use a helper function to sort the changes before comparing them.

## Related Issues
#32 

## Notes
These changes are pretty straightforward, just adds the compare function to the cli commands, but this is on top of Michaels WIP work. I did have to make a couple changes to get things building that I suspect Michael may have already handled in his code, so let me know if there are any conflicts you'd like me to sort out. 

## Follow-up Tasks
Introducing a simple comparison between two files is a good place to start. 

However, long term I wonder if we could make it operate with a little more context awareness.

I use aws cdk a lot for Infrastructure as Code, and I'm a fan of it's [cdk diff](https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd-diff.html) command. It has a pretty simple dev ex and it's behavior reminds me of what we're doing here. 

At any time, I can check my branche's IaC stack differences against another environment. 

I can branch off `main` and change my stacks, then run: 
- `cdk diff --profile dev` to check what the diff of my local is against dev
- `cdk diff --profile prod` to check what the diff of my local is against prod
and so forth. 

It might be cool in the future if we could have a simple `openfeature compare --env prod` pattern to abstract the need to define paths for the compare. 

I think as we add further foundational features, like `openfeature pull`, it might assist us achieving such a pattern.  

## How to test

manual testing: 
1. [ ] `go build -o openfeature`
2. [ ] `sudo mv openfeature /usr/local/bin/`
3. [ ] `openfeature compare <pathToOld> <pathToNew>`

unit tests:
- [ ] `go test .`

