### PR TITLE
feat: adds compare command

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/open-feature/cli/internal/manifest"
+	"github.com/spf13/cobra"
+)
+
+func GetCompareCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "compare",
+		Short: "Compare two manifest files",
+		Long:  `Compare two manifest files and list the changes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("please provide two manifest files to compare")
+			}
+
+			oldManifest, err := manifest.Load(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to load old manifest: %w", err)
+			}
+
+			newManifest, err := manifest.Load(args[1])
+			if err != nil {
+				return fmt.Errorf("failed to load new manifest: %w", err)
+			}
+
+			changes, err := manifest.Compare(oldManifest, newManifest)
+			if err != nil {
+				return fmt.Errorf("failed to compare manifests: %w", err)
+			}
+
+			for _, change := range changes {
+				fmt.Printf("%s: %s\n", change.Type, change.Path)
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -1,42 +1,184 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/open-feature/cli/internal/manifest"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
+// Updated to rename color mode to tree mode
 func GetCompareCmd() *cobra.Command {
-	return &cobra.Command{
+	compareCmd := &cobra.Command{
 		Use:   "compare",
-		Short: "Compare two manifest files",
-		Long:  `Compare two manifest files and list the changes`,
+		Short: "Compare two feature flag manifests",
+		Long:  "Compare two OpenFeature flag manifests and display the differences in a structured format.",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initializeConfig(cmd, "compare")
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 2 {
-				return fmt.Errorf("please provide two manifest files to compare")
+			// Get flags
+			sourcePath, _ := cmd.Flags().GetString("source")
+			targetPath, _ := cmd.Flags().GetString("target")
+			flatOutput, _ := cmd.Flags().GetBool("flat")
+
+			// Validate flags
+			if sourcePath == "" || targetPath == "" {
+				return fmt.Errorf("both --source and --target flags are required")
 			}
 
-			oldManifest, err := manifest.Load(args[0])
+			// Load manifests
+			sourceManifest, err := loadManifest(sourcePath)
 			if err != nil {
-				return fmt.Errorf("failed to load old manifest: %w", err)
+				return fmt.Errorf("error loading source manifest: %w", err)
 			}
 
-			newManifest, err := manifest.Load(args[1])
+			targetManifest, err := loadManifest(targetPath)
 			if err != nil {
-				return fmt.Errorf("failed to load new manifest: %w", err)
+				return fmt.Errorf("error loading target manifest: %w", err)
 			}
 
-			changes, err := manifest.Compare(oldManifest, newManifest)
+			// Compare manifests
+			changes, err := manifest.Compare(sourceManifest, targetManifest)
 			if err != nil {
-				return fmt.Errorf("failed to compare manifests: %w", err)
+				return fmt.Errorf("error comparing manifests: %w", err)
 			}
 
-			for _, change := range changes {
-				fmt.Printf("%s: %s\n", change.Type, change.Path)
+			// No changes
+			if len(changes) == 0 {
+				pterm.Success.Println("No differences found between the manifests.")
+				return nil
 			}
 
-			return nil
+			// Render differences based on the output mode
+			if flatOutput {
+				return renderFlatDiff(changes, cmd)
+			}
+			return renderTreeDiff(changes, cmd)
 		},
 	}
+
+	// Add flags specific to compare command
+	compareCmd.Flags().String("source", "", "Path to the source manifest file")
+	compareCmd.Flags().String("target", "", "Path to the target manifest file")
+	compareCmd.Flags().Bool("flat", false, "Display differences in a flat format")
+
+	// Mark required flags
+	_ = compareCmd.MarkFlagRequired("source")
+	_ = compareCmd.MarkFlagRequired("target")
+
+	return compareCmd
+}
+
+// loadManifest loads and unmarshals a manifest file from the given path
+func loadManifest(path string) (*manifest.Manifest, error) {
+	// Read file
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	// Unmarshal JSON
+	var m manifest.Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("error unmarshaling JSON: %w", err)
+	}
+
+	return &m, nil
+}
+
+// renderTreeDiff renders changes with tree-structured inline differences
+func renderTreeDiff(changes []manifest.Change, cmd *cobra.Command) error {
+	pterm.Info.Printf("Found %d difference(s) between manifests:\n\n", len(changes))
+
+	// Group changes by type for easier reading
+	var (
+		additions     []manifest.Change
+		removals      []manifest.Change
+		modifications []manifest.Change
+	)
+
+	for _, change := range changes {
+		switch change.Type {
+		case "add":
+			additions = append(additions, change)
+		case "remove":
+			removals = append(removals, change)
+		case "change":
+			modifications = append(modifications, change)
+		}
+	}
+
+	// Print additions
+	if len(additions) > 0 {
+		pterm.FgGreen.Println("◆ Additions:")
+		for _, change := range additions {
+			flagName := strings.TrimPrefix(change.Path, "flags.")
+			pterm.FgGreen.Printf("  + %s\n", flagName)
+			valueJSON, _ := json.MarshalIndent(change.NewValue, "    ", "  ")
+			fmt.Printf("    %s\n", valueJSON)
+		}
+		fmt.Println()
+	}
+
+	// Print removals
+	if len(removals) > 0 {
+		pterm.FgRed.Println("◆ Removals:")
+		for _, change := range removals {
+			flagName := strings.TrimPrefix(change.Path, "flags.")
+			pterm.FgRed.Printf("  - %s\n", flagName)
+			valueJSON, _ := json.MarshalIndent(change.OldValue, "    ", "  ")
+			fmt.Printf("    %s\n", valueJSON)
+		}
+		fmt.Println()
+	}
+
+	// Print modifications
+	if len(modifications) > 0 {
+		pterm.FgYellow.Println("◆ Modifications:")
+		for _, change := range modifications {
+			flagName := strings.TrimPrefix(change.Path, "flags.")
+			pterm.FgYellow.Printf("  ~ %s\n", flagName)
+
+			// Marshall the values
+			oldJSON, _ := json.MarshalIndent(change.OldValue, "", "  ")
+			newJSON, _ := json.MarshalIndent(change.NewValue, "", "  ")
+
+			// Print the diff
+			fmt.Println("    Before:")
+			for _, line := range strings.Split(string(oldJSON), "\n") {
+				fmt.Printf("      %s\n", line)
+			}
+
+			fmt.Println("    After:")
+			for _, line := range strings.Split(string(newJSON), "\n") {
+				fmt.Printf("      %s\n", line)
+			}
+		}
+	}
+
+	return nil
+}
+
+// renderFlatDiff renders changes in a flat format
+func renderFlatDiff(changes []manifest.Change, cmd *cobra.Command) error {
+	pterm.Info.Printf("Found %d difference(s) between manifests:\n\n", len(changes))
+
+	for _, change := range changes {
+		flagName := strings.TrimPrefix(change.Path, "flags.")
+		switch change.Type {
+		case "add":
+			pterm.FgGreen.Printf("+ %s\n", flagName)
+		case "remove":
+			pterm.FgRed.Printf("- %s\n", flagName)
+		case "change":
+			pterm.FgYellow.Printf("~ %s\n", flagName)
+		}
+	}
+
+	return nil
 }

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/open-feature/cli/internal/config"
 	"github.com/open-feature/cli/internal/manifest"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
-// Updated to rename color mode to tree mode
 func GetCompareCmd() *cobra.Command {
 	compareCmd := &cobra.Command{
 		Use:   "compare",
@@ -22,13 +22,13 @@ func GetCompareCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get flags
-			sourcePath, _ := cmd.Flags().GetString("source")
-			targetPath, _ := cmd.Flags().GetString("target")
+			sourcePath := config.GetManifestPath(cmd)
+			targetPath, _ := cmd.Flags().GetString("against")
 			flatOutput, _ := cmd.Flags().GetBool("flat")
 
 			// Validate flags
 			if sourcePath == "" || targetPath == "" {
-				return fmt.Errorf("both --source and --target flags are required")
+				return fmt.Errorf("both source (--manifest) and target (--against) paths are required")
 			}
 
 			// Load manifests
@@ -63,13 +63,11 @@ func GetCompareCmd() *cobra.Command {
 	}
 
 	// Add flags specific to compare command
-	compareCmd.Flags().String("source", "", "Path to the source manifest file")
-	compareCmd.Flags().String("target", "", "Path to the target manifest file")
+	compareCmd.Flags().StringP("against", "a", "", "Path to the target manifest file to compare against")
 	compareCmd.Flags().Bool("flat", false, "Display differences in a flat format")
 
 	// Mark required flags
-	_ = compareCmd.MarkFlagRequired("source")
-	_ = compareCmd.MarkFlagRequired("target")
+	_ = compareCmd.MarkFlagRequired("against")
 
 	return compareCmd
 }

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -13,11 +13,8 @@ func TestGetCompareCmd(t *testing.T) {
 	assert.Equal(t, "Compare two feature flag manifests", cmd.Short)
 
 	// Verify flags exist
-	sourceFlag := cmd.Flag("source")
-	assert.NotNil(t, sourceFlag)
-
-	targetFlag := cmd.Flag("target")
-	assert.NotNil(t, targetFlag)
+	againstFlag := cmd.Flag("against")
+	assert.NotNil(t, againstFlag)
 
 	// Verify optional flags
 	flatFlag := cmd.Flag("flat")
@@ -29,16 +26,18 @@ func TestCompareManifests(t *testing.T) {
 	// This test mainly verifies the command executes without errors
 	// since stdout capture is difficult with pterm usage
 
-	cmd := GetCompareCmd()
+	// Need to use the root command to properly inherit the manifest flag
+	rootCmd := GetRootCmd()
 
 	// Setup command line arguments
-	cmd.SetArgs([]string{
-		"--source", "testdata/source_manifest.json",
-		"--target", "testdata/target_manifest.json",
+	rootCmd.SetArgs([]string{
+		"compare",
+		"--manifest", "testdata/source_manifest.json",
+		"--against", "testdata/target_manifest.json",
 		"--flat",
 	})
 
 	// Execute command
-	err := cmd.Execute()
+	err := rootCmd.Execute()
 	assert.NoError(t, err, "Command should execute without errors")
 }

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCompareCmd(t *testing.T) {
+	cmd := GetCompareCmd()
+
+	assert.Equal(t, "compare", cmd.Use)
+	assert.Equal(t, "Compare two feature flag manifests", cmd.Short)
+
+	// Verify flags exist
+	sourceFlag := cmd.Flag("source")
+	assert.NotNil(t, sourceFlag)
+
+	targetFlag := cmd.Flag("target")
+	assert.NotNil(t, targetFlag)
+
+	// Verify optional flags
+	flatFlag := cmd.Flag("flat")
+	assert.NotNil(t, flatFlag)
+	assert.Equal(t, "false", flatFlag.DefValue)
+}
+
+func TestCompareManifests(t *testing.T) {
+	// This test mainly verifies the command executes without errors
+	// since stdout capture is difficult with pterm usage
+
+	cmd := GetCompareCmd()
+
+	// Setup command line arguments
+	cmd.SetArgs([]string{
+		"--source", "testdata/source_manifest.json",
+		"--target", "testdata/target_manifest.json",
+		"--flat",
+	})
+
+	// Execute command
+	err := cmd.Execute()
+	assert.NoError(t, err, "Command should execute without errors")
+}

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,28 +17,34 @@ func TestGetCompareCmd(t *testing.T) {
 	againstFlag := cmd.Flag("against")
 	assert.NotNil(t, againstFlag)
 
-	// Verify optional flags
-	flatFlag := cmd.Flag("flat")
-	assert.NotNil(t, flatFlag)
-	assert.Equal(t, "false", flatFlag.DefValue)
+	// Verify output flag
+	outputFlag := cmd.Flag("output")
+	assert.NotNil(t, outputFlag)
+	assert.Equal(t, "tree", outputFlag.DefValue)
 }
 
 func TestCompareManifests(t *testing.T) {
 	// This test mainly verifies the command executes without errors
-	// since stdout capture is difficult with pterm usage
+	// with each of the supported output formats
 
-	// Need to use the root command to properly inherit the manifest flag
-	rootCmd := GetRootCmd()
+	formats := []string{"tree", "flat", "json"}
 
-	// Setup command line arguments
-	rootCmd.SetArgs([]string{
-		"compare",
-		"--manifest", "testdata/source_manifest.json",
-		"--against", "testdata/target_manifest.json",
-		"--flat",
-	})
+	for _, format := range formats {
+		t.Run(fmt.Sprintf("output_format_%s", format), func(t *testing.T) {
+			// Need to use the root command to properly inherit the manifest flag
+			rootCmd := GetRootCmd()
 
-	// Execute command
-	err := rootCmd.Execute()
-	assert.NoError(t, err, "Command should execute without errors")
+			// Setup command line arguments
+			rootCmd.SetArgs([]string{
+				"compare",
+				"--manifest", "testdata/source_manifest.json",
+				"--against", "testdata/target_manifest.json",
+				"--output", format,
+			})
+
+			// Execute command
+			err := rootCmd.Execute()
+			assert.NoError(t, err, "Command should execute without errors with output format: "+format)
+		})
+	}
 }

--- a/cmd/compare_test.go
+++ b/cmd/compare_test.go
@@ -27,7 +27,7 @@ func TestCompareManifests(t *testing.T) {
 	// This test mainly verifies the command executes without errors
 	// with each of the supported output formats
 
-	formats := []string{"tree", "flat", "json"}
+	formats := []string{"tree", "flat", "json", "yaml"}
 
 	for _, format := range formats {
 		t.Run(fmt.Sprintf("output_format_%s", format), func(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ func GetRootCmd() *cobra.Command {
 	rootCmd.AddCommand(GetVersionCmd())
 	rootCmd.AddCommand(GetInitCmd())
 	rootCmd.AddCommand(GetGenerateCmd())
+	rootCmd.AddCommand(GetCompareCmd())
 
 	// Add a custom error handler after the command is created
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {

--- a/cmd/testdata/source_manifest.json
+++ b/cmd/testdata/source_manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/open-feature/cli/refs/heads/main/schema/v0/flag_manifest.json",
+  "flags": {
+    "darkMode": {
+      "flagType": "boolean",
+      "description": "Enable dark mode",
+      "defaultValue": false
+    },
+    "backgroundColor": {
+      "flagType": "string",
+      "description": "Background color for the application",
+      "defaultValue": "white"
+    },
+    "maxItems": {
+      "flagType": "integer",
+      "description": "Maximum number of items to display",
+      "defaultValue": 10
+    }
+  }
+}

--- a/cmd/testdata/target_manifest.json
+++ b/cmd/testdata/target_manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/open-feature/cli/refs/heads/main/schema/v0/flag_manifest.json",
+  "flags": {
+    "darkMode": {
+      "flagType": "boolean",
+      "description": "Enable dark mode for the application",
+      "defaultValue": true
+    },
+    "backgroundColor": {
+      "flagType": "string",
+      "description": "Background color for the application",
+      "defaultValue": "black"
+    },
+    "welcomeMessage": {
+      "flagType": "string",
+      "description": "Welcome message to display",
+      "defaultValue": "Hello, Welcome to OpenFeature!"
+    }
+  }
+}

--- a/docs/commands/openfeature.md
+++ b/docs/commands/openfeature.md
@@ -23,6 +23,7 @@ openfeature [flags]
 
 ### SEE ALSO
 
+* [openfeature compare](openfeature_compare.md)	 - Compare two manifest files
 * [openfeature generate](openfeature_generate.md)	 - Generate typesafe OpenFeature accessors.
 * [openfeature init](openfeature_init.md)	 - Initialize a new project
 * [openfeature version](openfeature_version.md)	 - Print the version number of the OpenFeature CLI

--- a/docs/commands/openfeature.md
+++ b/docs/commands/openfeature.md
@@ -23,7 +23,7 @@ openfeature [flags]
 
 ### SEE ALSO
 
-* [openfeature compare](openfeature_compare.md)	 - Compare two manifest files
+* [openfeature compare](openfeature_compare.md)	 - Compare two feature flag manifests
 * [openfeature generate](openfeature_generate.md)	 - Generate typesafe OpenFeature accessors.
 * [openfeature init](openfeature_init.md)	 - Initialize a new project
 * [openfeature version](openfeature_version.md)	 - Print the version number of the OpenFeature CLI

--- a/docs/commands/openfeature_compare.md
+++ b/docs/commands/openfeature_compare.md
@@ -16,8 +16,8 @@ openfeature compare [flags]
 
 ```
   -a, --against string   Path to the target manifest file to compare against
-      --flat             Display differences in a flat format
   -h, --help             help for compare
+  -o, --output string    Output format. Valid formats: tree, flat, json (default "tree")
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/openfeature_compare.md
+++ b/docs/commands/openfeature_compare.md
@@ -15,10 +15,9 @@ openfeature compare [flags]
 ### Options
 
 ```
-      --flat            Display differences in a flat format
-  -h, --help            help for compare
-      --source string   Path to the source manifest file
-      --target string   Path to the target manifest file
+  -a, --against string   Path to the target manifest file to compare against
+      --flat             Display differences in a flat format
+  -h, --help             help for compare
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/openfeature_compare.md
+++ b/docs/commands/openfeature_compare.md
@@ -1,0 +1,32 @@
+<!-- markdownlint-disable-file -->
+<!-- WARNING: THIS DOC IS AUTO-GENERATED. DO NOT EDIT! -->
+## openfeature compare
+
+Compare two manifest files
+
+### Synopsis
+
+Compare two manifest files and list the changes
+
+```
+openfeature compare [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for compare
+```
+
+### Options inherited from parent commands
+
+```
+      --debug             Enable debug logging
+  -m, --manifest string   Path to the flag manifest (default "flags.json")
+      --no-input          Disable interactive prompts
+```
+
+### SEE ALSO
+
+* [openfeature](openfeature.md)	 - CLI for OpenFeature.
+

--- a/docs/commands/openfeature_compare.md
+++ b/docs/commands/openfeature_compare.md
@@ -17,7 +17,7 @@ openfeature compare [flags]
 ```
   -a, --against string   Path to the target manifest file to compare against
   -h, --help             help for compare
-  -o, --output string    Output format. Valid formats: tree, flat, json (default "tree")
+  -o, --output string    Output format. Valid formats: tree, flat, json, yaml (default "tree")
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/openfeature_compare.md
+++ b/docs/commands/openfeature_compare.md
@@ -2,11 +2,11 @@
 <!-- WARNING: THIS DOC IS AUTO-GENERATED. DO NOT EDIT! -->
 ## openfeature compare
 
-Compare two manifest files
+Compare two feature flag manifests
 
 ### Synopsis
 
-Compare two manifest files and list the changes
+Compare two OpenFeature flag manifests and display the differences in a structured format.
 
 ```
 openfeature compare [flags]
@@ -15,7 +15,10 @@ openfeature compare [flags]
 ### Options
 
 ```
-  -h, --help   help for compare
+      --flat            Display differences in a flat format
+  -h, --help            help for compare
+      --source string   Path to the source manifest file
+      --target string   Path to the target manifest file
 ```
 
 ### Options inherited from parent commands

--- a/internal/manifest/compare_test.go
+++ b/internal/manifest/compare_test.go
@@ -1,0 +1,65 @@
+package manifest
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCompareDifferentManifests(t *testing.T) {
+	oldManifest := &Manifest{
+		Flags: map[string]any{
+			"flag1": "value1",
+			"flag2": "value2",
+		},
+	}
+
+	newManifest := &Manifest{
+		Flags: map[string]any{
+			"flag1": "value1",
+			"flag2": "newValue2",
+			"flag3": "value3",
+		},
+	}
+
+	changes, err := Compare(oldManifest, newManifest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedChanges := []Change{
+		{Type: "change", Path: "flags.flag2", OldValue: "value2", NewValue: "newValue2"},
+		{Type: "add", Path: "flags.flag3", NewValue: "value3"},
+	}
+
+	sortChanges(changes)
+	sortChanges(expectedChanges)
+
+	if !reflect.DeepEqual(changes, expectedChanges) {
+		t.Errorf("expected %v, got %v", expectedChanges, changes)
+	}
+}
+
+func TestCompareIdenticalManifests(t *testing.T) {
+	manifest := &Manifest{
+		Flags: map[string]any{
+			"flag1": "value1",
+			"flag2": "value2",
+		},
+	}
+
+	changes, err := Compare(manifest, manifest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(changes) != 0 {
+		t.Errorf("expected no changes, got %v", changes)
+	}
+}
+
+func sortChanges(changes []Change) {
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Path < changes[j].Path
+	})
+}

--- a/internal/manifest/manage.go
+++ b/internal/manifest/manage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/open-feature/cli/internal/filesystem"
+	"github.com/spf13/afero"
 )
 
 type initManifest struct {
@@ -24,4 +25,20 @@ func Create(path string) error {
 		return err
 	}
 	return filesystem.WriteFile(path, formattedInitManifest)
+}
+
+// Load loads a manifest from a JSON file, unmarshals it, and returns a Manifest object.
+func Load(path string) (*Manifest, error) {
+	fs := filesystem.FileSystem()
+	data, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+
+	return &m, nil
 }

--- a/internal/manifest/output.go
+++ b/internal/manifest/output.go
@@ -1,0 +1,32 @@
+package manifest
+
+// OutputFormat represents the available output formats for the compare command
+type OutputFormat string
+
+const (
+	// OutputFormatTree represents the tree output format (default)
+	OutputFormatTree OutputFormat = "tree"
+	// OutputFormatFlat represents the flat output format
+	OutputFormatFlat OutputFormat = "flat"
+	// OutputFormatJSON represents the JSON output format
+	OutputFormatJSON OutputFormat = "json"
+)
+
+// IsValidOutputFormat checks if the given format is a valid output format
+func IsValidOutputFormat(format string) bool {
+	switch OutputFormat(format) {
+	case OutputFormatTree, OutputFormatFlat, OutputFormatJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+// GetValidOutputFormats returns a list of all valid output formats
+func GetValidOutputFormats() []string {
+	return []string{
+		string(OutputFormatTree),
+		string(OutputFormatFlat),
+		string(OutputFormatJSON),
+	}
+}

--- a/internal/manifest/output.go
+++ b/internal/manifest/output.go
@@ -10,12 +10,14 @@ const (
 	OutputFormatFlat OutputFormat = "flat"
 	// OutputFormatJSON represents the JSON output format
 	OutputFormatJSON OutputFormat = "json"
+	// OutputFormatYAML represents the YAML output format
+	OutputFormatYAML OutputFormat = "yaml"
 )
 
 // IsValidOutputFormat checks if the given format is a valid output format
 func IsValidOutputFormat(format string) bool {
 	switch OutputFormat(format) {
-	case OutputFormatTree, OutputFormatFlat, OutputFormatJSON:
+	case OutputFormatTree, OutputFormatFlat, OutputFormatJSON, OutputFormatYAML:
 		return true
 	default:
 		return false
@@ -28,5 +30,6 @@ func GetValidOutputFormats() []string {
 		string(OutputFormatTree),
 		string(OutputFormatFlat),
 		string(OutputFormatJSON),
+		string(OutputFormatYAML),
 	}
 }


### PR DESCRIPTION
## This PR
Adds the compare command to compare flags.
Adds multiple output formats for compare.

_tree mode_
<img width="659" alt="image" src="https://github.com/user-attachments/assets/a6b4799a-405c-4a46-b653-8e0fbfeab218" />


_flat mode_
<img width="674" alt="image" src="https://github.com/user-attachments/assets/18ff9ffe-67cb-4f89-ae4b-cffe310fd551" />

Also JSON and YAML outputs. 

## Related Issues
#89 

### Compare Command Details

1. **Improved flag handling**:
   - Reuses the existing manifest flag (`-m`, `--manifest`) as the source
   - Adds `-a`, `--against` flag to specify the target manifest for comparison
   
2. **Flexible output formats**:
   - Replaced `--flat` flag with a more versatile `-o`, `--output` flag
   - Added four output formats for different use cases:
     - `tree` (default): Detailed hierarchical display with context
     - `flat`: Simplified, compact view showing only flag names
     - `json`: Structured data format for programmatic consumption
     - `yaml`: Alternative structured data format
   
3. **Compare Result organization**:
   - visual grouping of changes by type (additions, removals, modifications)
   - Color-coded output for improved clarity

## How to Test

Test each output format to verify correct behavior:

```bash
# Install this branch version of openfeature
go install .

# Default tree output
openfeature compare -m cmd/testdata/source_manifest.json -a cmd/testdata/target_manifest.json

# Flat output
openfeature compare -m cmd/testdata/source_manifest.json -a cmd/testdata/target_manifest.json -o flat

# JSON output 
openfeature compare -m cmd/testdata/source_manifest.json -a cmd/testdata/target_manifest.json -o json

# YAML output
openfeature compare -m cmd/testdata/source_manifest.json -a cmd/testdata/target_manifest.json -o yaml
```

Verify that:
- The command shows differences correctly
- All output formats display the expected information
- Error handling works properly with invalid formats