### PR TITLE
fix: use the correct json schema url in init command

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/open-feature/cli/internal/config"
+	"github.com/open-feature/cli/internal/filesystem"
+	"github.com/spf13/afero"
+)
+
+func TestInitCmd(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	filesystem.SetFileSystem(fs)
+	outputFile := "flags-test.json"
+	cmd := GetInitCmd()
+	// global flag exists on root only.
+	config.AddRootFlags(cmd)
+
+	cmd.SetArgs([]string{
+		"-m",
+		outputFile,
+	})
+	err := cmd.Execute()
+	if err != nil {
+		t.Error(err)
+	}
+	compareOutput(t, "testdata/success_init.golden", outputFile, fs)
+}

--- a/cmd/testdata/success_init.golden
+++ b/cmd/testdata/success_init.golden
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://raw.githubusercontent.com/open-feature/cli/main/schema/v0/flag-manifest.json",
+  "flags": {}
+}

--- a/internal/manifest/manage.go
+++ b/internal/manifest/manage.go
@@ -14,7 +14,7 @@ type initManifest struct {
 // Create creates a new manifest file at the given path.
 func Create(path string) error {
 	m := &initManifest{
-		Schema:  "https://raw.githubusercontent.com/open-feature/cli/refs/heads/main/schema/v0/flag_manifest.json",
+		Schema: "https://raw.githubusercontent.com/open-feature/cli/main/schema/v0/flag-manifest.json",
 		Manifest: Manifest{
 			Flags: map[string]any{},
 		},


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

<!-- add the description of the PR here -->

- fixes the issue for `init` command which generates the manifest file with wrong url to the json schema. It used `flag_manifest.json` instead of `flag-manifest.json`.
- adds the basic test for `init` command

<!-- add here the GitHub issue that this PR resolves if applicable -->

<!-- any additional notes for this PR -->

<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

<!-- if applicable, add testing instructions under this section -->
