### PR TITLE
fix: Naming of generated java class

### DIFF
--- a/cmd/testdata/success_java.golden
+++ b/cmd/testdata/success_java.golden
@@ -6,9 +6,9 @@ import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.FlagEvaluationDetails;
 import dev.openfeature.sdk.OpenFeatureAPI;
 
-public final class Generated {
+public final class OpenFeature {
 
-    private Generated() {} // prevent instantiation
+    private OpenFeature() {} // prevent instantiation
 
     public interface GeneratedClient {
 

--- a/internal/generators/java/java.tmpl
+++ b/internal/generators/java/java.tmpl
@@ -6,9 +6,9 @@ import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.FlagEvaluationDetails;
 import dev.openfeature.sdk.OpenFeatureAPI;
 
-public final class Generated {
+public final class OpenFeature {
 
-    private Generated() {} // prevent instantiation
+    private OpenFeature() {} // prevent instantiation
 
     public interface GeneratedClient {
         {{ range .Flagset.Flags }}


### PR DESCRIPTION
Java expects to have a class with the same name as the file within the file. This constraint was violated, and renaming the class or the file was needed.

```
Class 'Generated' is public, should be declared in a file named 'Generated.java'
```


