### PR TITLE
docs: update README.md formatting for openfeature.dev website docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ flowchart LR
   config --> args
 ```
 
+<!-- x-hide-in-docs-start -->
 ## Get Involved
 
 - **GitHub Repository**: [open-feature/cli](https://github.com/open-feature/cli)
@@ -253,7 +254,6 @@ flowchart LR
 
 For more information, visit our [community page](https://openfeature.dev/community/).
 
-<!-- x-hide-in-docs-start -->
 ## Support the project
 
 - Give this repo a ⭐️!


### PR DESCRIPTION
Updating the format of `README.md` to better format for adding the CLI to the openfeature.dev website. This README will be used for documentation under `openfeature.dev/docs/reference/other-technologies/cli`, just as the SDKs docs are published from their repo's README's.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
