### PR TITLE
ci(integration): bump Dagger Go base image to 1.25-alpine

### DIFF
--- a/test/integration/cmd/angular/run.go
+++ b/test/integration/cmd/angular/run.go
@@ -39,7 +39,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 
 	// Build the CLI in a Go container
 	cli := client.Container().
-		From("golang:1.24-alpine").
+		From("golang:1.25-alpine").
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "build", "-o", "cli", "./cmd/openfeature"})

--- a/test/integration/cmd/angular/run.go
+++ b/test/integration/cmd/angular/run.go
@@ -39,7 +39,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 
 	// Build the CLI in a Go container
 	cli := client.Container().
-		From("golang:1.25-alpine").
+		From(integration.GoBaseImage).
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "build", "-o", "cli", "./cmd/openfeature"})

--- a/test/integration/cmd/csharp/run.go
+++ b/test/integration/cmd/csharp/run.go
@@ -36,7 +36,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 
 	// Build the CLI
 	cli := client.Container().
-		From("golang:1.25-alpine").
+		From(integration.GoBaseImage).
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "build", "-o", "cli", "./cmd/openfeature"})

--- a/test/integration/cmd/csharp/run.go
+++ b/test/integration/cmd/csharp/run.go
@@ -36,7 +36,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 
 	// Build the CLI
 	cli := client.Container().
-		From("golang:1.24-alpine").
+		From("golang:1.25-alpine").
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "build", "-o", "cli", "./cmd/openfeature"})

--- a/test/integration/cmd/go/run.go
+++ b/test/integration/cmd/go/run.go
@@ -36,7 +36,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 
 	// Build the CLI
 	cli := client.Container().
-		From("golang:1.24-alpine").
+		From("golang:1.25-alpine").
 		WithExec([]string{"apk", "add", "--no-cache", "git"}).
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
@@ -57,7 +57,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 
 	// Test Go compilation with the generated files
 	goContainer := client.Container().
-		From("golang:1.24-alpine").
+		From("golang:1.25-alpine").
 		WithExec([]string{"apk", "add", "--no-cache", "git"}).
 		WithWorkdir("/app").
 		WithDirectory("/app", testFiles).

--- a/test/integration/cmd/go/run.go
+++ b/test/integration/cmd/go/run.go
@@ -34,10 +34,16 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 		Include: []string{"test.go", "go.mod"},
 	})
 
+	// goBase returns a Go container with git installed, used both to build
+	// the CLI and to compile the generated client against the test fixture.
+	goBase := func() *dagger.Container {
+		return client.Container().
+			From(integration.GoBaseImage).
+			WithExec([]string{"apk", "add", "--no-cache", "git"})
+	}
+
 	// Build the CLI
-	cli := client.Container().
-		From("golang:1.25-alpine").
-		WithExec([]string{"apk", "add", "--no-cache", "git"}).
+	cli := goBase().
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "mod", "tidy"}).
@@ -56,9 +62,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 	generatedFiles := generated.Directory("/tmp/generated")
 
 	// Test Go compilation with the generated files
-	goContainer := client.Container().
-		From("golang:1.25-alpine").
-		WithExec([]string{"apk", "add", "--no-cache", "git"}).
+	goContainer := goBase().
 		WithWorkdir("/app").
 		WithDirectory("/app", testFiles).
 		WithDirectory("/app/openfeature", generatedFiles).

--- a/test/integration/cmd/nodejs/run.go
+++ b/test/integration/cmd/nodejs/run.go
@@ -29,7 +29,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 	})
 
 	cli := client.Container().
-		From("golang:1.24-alpine").
+		From("golang:1.25-alpine").
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "build", "-o", "cli", "./cmd/openfeature"})

--- a/test/integration/cmd/nodejs/run.go
+++ b/test/integration/cmd/nodejs/run.go
@@ -29,7 +29,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 	})
 
 	cli := client.Container().
-		From("golang:1.25-alpine").
+		From(integration.GoBaseImage).
 		WithDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"go", "build", "-o", "cli", "./cmd/openfeature"})

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -8,6 +8,11 @@ import (
 	"dagger.io/dagger"
 )
 
+// GoBaseImage is the Go container image used to build the CLI inside
+// integration test pipelines. Centralized here so the version is bumped
+// in a single place when go.mod's required Go version changes.
+const GoBaseImage = "golang:1.25-alpine"
+
 // Test defines the interface for all integration tests
 type Test interface {
 	// Run executes the integration test with the given Dagger client

--- a/test/new-generator.md
+++ b/test/new-generator.md
@@ -59,9 +59,10 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
   Include: []string{"test_openfeature.py", "requirements.txt"},
  })
 
- // Build the CLI
+ // Build the CLI. Use integration.GoBaseImage so the Go version is
+ // bumped in a single place when go.mod changes.
  cli := client.Container().
-  From("golang:1.25-alpine").
+  From(integration.GoBaseImage).
   WithDirectory("/src", source).
   WithWorkdir("/src").
   WithExec([]string{"go", "build", "-o", "cli"})

--- a/test/new-generator.md
+++ b/test/new-generator.md
@@ -61,7 +61,7 @@ func (t *Test) Run(ctx context.Context, client *dagger.Client) (*dagger.Containe
 
  // Build the CLI
  cli := client.Container().
-  From("golang:1.24-alpine").
+  From("golang:1.25-alpine").
   WithDirectory("/src", source).
   WithWorkdir("/src").
   WithExec([]string{"go", "build", "-o", "cli"})


### PR DESCRIPTION
## Summary

The Dagger integration test containers and the new-generator example documentation pin the Go base image to `golang:1.24-alpine`, but `go.mod` requires `go >= 1.25.0`. As a result, the **Generator Integration Tests** workflow fails on every PR with:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

This affects every open PR — including the maintainers' own release PR (#234) — because the CLI is rebuilt inside the 1.24 container during the C#, Node.js, Angular, and Go integration runs.

This change bumps the base image to `golang:1.25-alpine` in:

- `test/integration/cmd/csharp/run.go`
- `test/integration/cmd/nodejs/run.go`
- `test/integration/cmd/angular/run.go`
- `test/integration/cmd/go/run.go` (2 occurrences — CLI build container and Go fixture compile container)
- `test/new-generator.md` (the documented example for adding a new generator)

The `toolchain go1.24.1` line in `test/go-integration/go.mod` is a minimum-toolchain directive and still satisfied by Go 1.25, so it is left alone.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `make ci` passes locally (fmt, lint, test, verify-generate)
- [ ] Generator Integration Tests pass in CI on this PR (the actual smoke test)

Made with [Cursor](https://cursor.com)